### PR TITLE
Agregar cuantas puede tomar

### DIFF
--- a/src/Cliente.hs
+++ b/src/Cliente.hs
@@ -9,7 +9,10 @@ module Cliente
     jarraLoca,
     klusener,
     tintico,
-    soda
+    soda,
+    tomarTragos,
+    dameOtro,
+    cualesPuedeTomar,
     )
     where
 
@@ -19,9 +22,10 @@ import Data.Char
 
 data TipoCliente = 
     Cliente {
-    nombre      :: String,
-    resistencia :: Int,
-    amigos      :: [TipoCliente]}
+    nombre          :: String,
+    resistencia     :: Int,
+    amigos          :: [TipoCliente],
+    bebidas_tomadas :: [String]}
     deriving (Show)
 
 {-Un cliente se sabe comparar-}
@@ -35,7 +39,7 @@ esAmigo :: TipoCliente -> TipoCliente -> Bool
 esAmigo cliente amigo = elem amigo (amigos cliente)
 
 agregarAmigo :: TipoCliente -> TipoCliente -> TipoCliente
-agregarAmigo (Cliente nombre resistencia amigos) nuevo_amigo = Cliente nombre resistencia (nuevo_amigo:amigos)
+agregarAmigo (Cliente nombre resistencia amigos bebidas_tomadas) nuevo_amigo = Cliente nombre resistencia (nuevo_amigo:amigos) bebidas_tomadas
 --Otra forma de agregar el amigo es concatenando listas (hacer una lista con el nuevo_amigo)
 --agregarAmigo (Cliente nombre resistencia amigos) nuevo_amigo = Cliente nombre resistencia (amigos++[nuevo_amigo])
 
@@ -59,34 +63,34 @@ comoEsta cliente
 ----------------------------}
 
 grogXD:: TipoCliente -> TipoCliente
-grogXD (Cliente nombre resistencia amigos) = (Cliente nombre 0 amigos)
+grogXD (Cliente nombre resistencia amigos bebidas_tomadas) = (Cliente nombre 0 amigos ("Grog XD":bebidas_tomadas))
 
 disminuirResistencia :: Int -> TipoCliente -> TipoCliente
-disminuirResistencia cantidad (Cliente nombre resistencia amigos) 
-    | resistencia > 10 = (Cliente nombre (resistencia-10) amigos)
-    | otherwise = (Cliente nombre 0 amigos)
+disminuirResistencia cantidad (Cliente nombre resistencia amigos bebidas_tomadas) 
+  | resistencia > cantidad = (Cliente nombre (resistencia-cantidad) amigos bebidas_tomadas)
+  | otherwise = (Cliente nombre 0 amigos bebidas_tomadas)
     
 jarraLoca :: TipoCliente -> TipoCliente
-jarraLoca (Cliente nombre resistencia amigos) = 
-        disminuirResistencia 10 (Cliente nombre resistencia (map (disminuirResistencia 10) amigos))
+jarraLoca (Cliente nombre resistencia amigos bebidas_tomadas) = 
+    disminuirResistencia 10 (Cliente nombre resistencia (map (disminuirResistencia 10) amigos) ("Jarra loca":bebidas_tomadas))
 
 klusener :: String -> TipoCliente -> TipoCliente
-klusener nombreBebida (Cliente nombre resistencia amigos) = 
-                disminuirResistencia (length nombreBebida) (Cliente nombre resistencia amigos)
+klusener nombreBebida (Cliente nombre resistencia amigos bebidas_tomadas) = 
+    disminuirResistencia (length nombreBebida) (Cliente nombre resistencia amigos (("Klusener de " ++ nombreBebida):bebidas_tomadas))
                 {-(Cliente nombre (disminuirResistencia (length nombreBebida) resistencia) amigos)-}
 
 tintico :: TipoCliente -> TipoCliente
-tintico (Cliente nombre resistencia amigos) = 
-                (Cliente nombre (resistencia + (5 * (length amigos))) amigos)
+tintico (Cliente nombre resistencia amigos bebidas_tomadas) = 
+    (Cliente nombre (resistencia + (5 * (length amigos))) amigos ("Tintico":bebidas_tomadas))
 
 soda :: Int -> TipoCliente -> TipoCliente
-soda fuerza (Cliente nombre resistencia amigos) = 
-                (Cliente (erpear fuerza nombre) resistencia amigos)
+soda fuerza (Cliente nombre resistencia amigos bebidas_tomadas) = 
+    (Cliente (erpear fuerza nombre) resistencia amigos (("Soda de fuerza " ++ show(fuerza)):bebidas_tomadas))
                 where erpear fuerza nombre = "e" ++ (replicate fuerza 'r') ++ "p" ++ nombre
 
 {- Objetivo 6 -}
 
 rescatarse :: TipoCliente -> Int -> TipoCliente
-rescatarse (Cliente nombre resistencia amigos) horas
-  | horas > 3 = Cliente nombre (resistencia+200) amigos
-  | otherwise = Cliente nombre (resistencia+100) amigos
+rescatarse (Cliente nombre resistencia amigos bebidas_tomadas) horas
+  | horas > 3 = Cliente nombre (resistencia+200) amigos bebidas_tomadas
+  | otherwise = Cliente nombre (resistencia+100) amigos bebidas_tomadas

--- a/src/Cliente.hs
+++ b/src/Cliente.hs
@@ -94,3 +94,20 @@ rescatarse :: TipoCliente -> Int -> TipoCliente
 rescatarse (Cliente nombre resistencia amigos bebidas_tomadas) horas
   | horas > 3 = Cliente nombre (resistencia+200) amigos bebidas_tomadas
   | otherwise = Cliente nombre (resistencia+100) amigos bebidas_tomadas
+
+
+{---------------------
+----Segunda parte-----
+----------------------}
+
+{- Objetivo 1 -}
+
+tomarTrago cliente trago =
+    trago cliente
+
+tomarTragos [] cliente = cliente
+tomarTragos (unTrago:otrosTragos) cliente = 
+    tomarTragos otrosTragos (unTrago cliente)
+    
+dameOtro (Cliente nombre resistencia amigos bebidas_tomadas) =
+    (Cliente nombre resistencia amigos ((head bebidas_tomadas):bebidas_tomadas))

--- a/src/clientes.hs
+++ b/src/clientes.hs
@@ -1,6 +1,6 @@
 import Cliente
 
-rodri       = Cliente "Rodri" 55 []
-marcos      = Cliente "Marcos" 40 [rodri]
-cristian    = Cliente "Cristian" 2 []
-ana         = Cliente "Ana" 120 [marcos, rodri]
+rodri       = Cliente "Rodri" 55 [] []
+marcos      = Cliente "Marcos" 40 [rodri] []
+cristian    = Cliente "Cristian" 2 [] []
+ana         = Cliente "Ana" 120 [marcos, rodri] []


### PR DESCRIPTION
Por cómo estaban modeladas las bebidas se complicaba
el asunto del `cuantasPuedeTomar`, porque hacía un `filter` de las bebidas
que te dejaban con la resistencia > 0, pero esa lista que te devolvía el
`filter`, eran las bebidas (que eran **funciones**) => el filter te devolvía
una **lista de funciones**.

Ahora está el tipo de dato `TipoBebida` (que tiene definido su
comportamiento para la función `show`), y ahora la función `tomarTrago`
es la que implementa la modificación al cliente según la bebida
(`tomarTrago` recibe una bebida y un cliente, y te devuelve un cliente).
Las implementaciones de las bebidas se mantienen iguales, obvio.

En fin, con este commit ya quedaría implementado hasta el Objetivo 2 de
la Segunda Parte